### PR TITLE
Rename version fields and more

### DIFF
--- a/include/mumble/Message.hpp
+++ b/include/mumble/Message.hpp
@@ -290,8 +290,8 @@ namespace udp {
 
 namespace tcp {
 	MUMBLE_MESSAGE_DECL(Version) {
-		uint32_t v1           = 0;
-		uint64_t v2           = 0;
+		uint32_t versionV1    = 0;
+		uint64_t versionV2    = 0;
 		std::string release   = {};
 		std::string os        = {};
 		std::string osVersion = {};
@@ -690,7 +690,7 @@ namespace udp {
 
 		bool requestExtendedInformation = false;
 
-		std::optional< uint64_t > serverVersion       = {};
+		std::optional< uint64_t > serverVersionV2     = {};
 		std::optional< uint32_t > userCount           = {};
 		std::optional< uint32_t > maxUserCount        = {};
 		std::optional< uint32_t > maxBandwidthPerUser = {};

--- a/include/mumble/Message.hpp
+++ b/include/mumble/Message.hpp
@@ -290,11 +290,10 @@ namespace udp {
 
 namespace tcp {
 	MUMBLE_MESSAGE_DECL(Version) {
-		uint32_t versionV1    = 0;
-		uint64_t versionV2    = 0;
-		std::string release   = {};
-		std::string os        = {};
-		std::string osVersion = {};
+		mumble::Version version = {};
+		std::string release     = {};
+		std::string os          = {};
+		std::string osVersion   = {};
 
 		MUMBLE_MESSAGE_COMMON(Version)
 	};
@@ -610,14 +609,14 @@ namespace tcp {
 		float tcpPingAvg    = 0;
 		float tcpPingVar    = 0;
 
-		Version version                     = {};
-		std::vector< int32_t > celtVersions = {};
-		IP address                          = {};
-		uint32_t bandwidth                  = 0;
-		uint32_t onlinesecs                 = 0;
-		uint32_t idlesecs                   = 0;
-		bool strongCertificate              = false;
-		bool opus                           = false;
+		mumble::tcp::Message::Version version = {};
+		std::vector< int32_t > celtVersions   = {};
+		IP address                            = {};
+		uint32_t bandwidth                    = 0;
+		uint32_t onlinesecs                   = 0;
+		uint32_t idlesecs                     = 0;
+		bool strongCertificate                = false;
+		bool opus                             = false;
 
 		MUMBLE_MESSAGE_COMMON(UserStats)
 	};
@@ -643,10 +642,9 @@ namespace tcp {
 	};
 
 	MUMBLE_MESSAGE_DECL(SuggestConfig) {
-		std::optional< uint32_t > versionV1 = {};
-		std::optional< uint64_t > versionV2 = {};
-		std::optional< bool > positional    = {};
-		std::optional< bool > pushToTalk    = {};
+		std::optional< mumble::Version > version = {};
+		std::optional< bool > positional         = {};
+		std::optional< bool > pushToTalk         = {};
 
 		MUMBLE_MESSAGE_COMMON(SuggestConfig)
 	};
@@ -690,7 +688,7 @@ namespace udp {
 
 		bool requestExtendedInformation = false;
 
-		std::optional< uint64_t > serverVersionV2     = {};
+		std::optional< mumble::Version > version      = {};
 		std::optional< uint32_t > userCount           = {};
 		std::optional< uint32_t > maxUserCount        = {};
 		std::optional< uint32_t > maxBandwidthPerUser = {};

--- a/include/mumble/Types.hpp
+++ b/include/mumble/Types.hpp
@@ -87,6 +87,10 @@ struct Version {
 			   | (std::min< uint32_t >(patch, std::numeric_limits< uint8_t >::max()) << offsetPatch32);
 	}
 
+	constexpr bool isValid() const {
+		return (major | minor | patch | extra) != 0;
+	}
+
 	static constexpr auto maskMajor64 = 0xFFFF000000000000;
 	static constexpr auto maskMinor64 = 0xFFFF00000000;
 	static constexpr auto maskPatch64 = 0xFFFF0000;

--- a/src/Pack.cpp
+++ b/src/Pack.cpp
@@ -73,8 +73,8 @@ TCP::Pack(const Message &message) {
 			auto &msg = static_cast< const Message::Version & >(message);
 
 			MumbleTCP::Version proto;
-			proto.set_version_v1(msg.v1);
-			proto.set_version_v2(msg.v2);
+			proto.set_version_v1(msg.versionV1);
+			proto.set_version_v2(msg.versionV2);
 			proto.set_release(msg.release);
 			proto.set_os(msg.os);
 			proto.set_os_version(msg.osVersion);
@@ -461,8 +461,8 @@ TCP::Pack(const Message &message) {
 			proto.set_tcp_ping_var(msg.tcpPingVar);
 
 			auto version = proto.mutable_version();
-			version->set_version_v1(msg.version.v1);
-			version->set_version_v2(msg.version.v2);
+			version->set_version_v1(msg.version.versionV1);
+			version->set_version_v2(msg.version.versionV2);
 			version->set_release(msg.version.release);
 			version->set_os(msg.version.os);
 			version->set_os_version(msg.version.osVersion);
@@ -590,8 +590,8 @@ UDP::Pack(const Message &message) {
 
 			proto.set_request_extended_information(msg.requestExtendedInformation);
 
-			if (msg.serverVersion) {
-				proto.set_server_version(msg.serverVersion.value());
+			if (msg.serverVersionV2) {
+				proto.set_server_version_v2(msg.serverVersionV2.value());
 			}
 			if (msg.userCount) {
 				proto.set_user_count(msg.userCount.value());
@@ -630,8 +630,8 @@ bool TCP::operator()(Message &message, uint32_t dataSize) const {
 			PARSE_RET
 
 			auto &msg     = static_cast< Message::Version     &>(message);
-			msg.v1        = proto.version_v1();
-			msg.v2        = proto.version_v2();
+			msg.versionV1 = proto.version_v1();
+			msg.versionV2 = proto.version_v2();
 			msg.release   = proto.release();
 			msg.os        = proto.os();
 			msg.osVersion = proto.os_version();
@@ -1027,8 +1027,8 @@ bool TCP::operator()(Message &message, uint32_t dataSize) const {
 			msg.tcpPingAvg = proto.tcp_ping_avg();
 			msg.tcpPingVar = proto.tcp_ping_var();
 
-			msg.version.v1        = proto.version().version_v1();
-			msg.version.v2        = proto.version().version_v2();
+			msg.version.versionV1 = proto.version().version_v1();
+			msg.version.versionV2 = proto.version().version_v2();
 			msg.version.release   = proto.version().release();
 			msg.version.os        = proto.version().os();
 			msg.version.osVersion = proto.version().os_version();
@@ -1173,7 +1173,7 @@ bool UDP::operator()(Message &message, uint32_t dataSize) const {
 			msg.requestExtendedInformation = proto.request_extended_information();
 
 			// FIXME: Check if fields are set once "optional" is in .proto file.
-			msg.serverVersion       = proto.server_version();
+			msg.serverVersionV2     = proto.server_version_v2();
 			msg.userCount           = proto.user_count();
 			msg.maxUserCount        = proto.max_user_count();
 			msg.maxBandwidthPerUser = proto.max_bandwidth_per_user();

--- a/src/example/ExampleClient/main.cpp
+++ b/src/example/ExampleClient/main.cpp
@@ -40,9 +40,8 @@ static Connection::Feedback connectionFeedback(Connection &connection, std::cond
 		printf("Connection opened!\n");
 
 		Message::Version ver;
-		ver.versionV1 = lib::version().blob32();
-		ver.versionV2 = lib::version().blob64();
-		ver.release   = "Custom client";
+		ver.version = lib::version();
+		ver.release = "Custom client";
 		connection.write(Pack(ver).buf());
 	};
 

--- a/src/example/ExampleClient/main.cpp
+++ b/src/example/ExampleClient/main.cpp
@@ -40,9 +40,9 @@ static Connection::Feedback connectionFeedback(Connection &connection, std::cond
 		printf("Connection opened!\n");
 
 		Message::Version ver;
-		ver.v1      = lib::version().blob32();
-		ver.v2      = lib::version().blob64();
-		ver.release = "Custom client";
+		ver.versionV1 = lib::version().blob32();
+		ver.versionV2 = lib::version().blob64();
+		ver.release   = "Custom client";
 		connection.write(Pack(ver).buf());
 	};
 

--- a/src/example/ExampleServer/Node.cpp
+++ b/src/example/ExampleServer/Node.cpp
@@ -164,9 +164,8 @@ bool Node::startTCP() {
 			switch (pack.type()) {
 				case Type::Version: {
 					Message::Version ver;
-					ver.versionV1 = lib::version().blob32();
-					ver.versionV2 = lib::version().blob64();
-					ver.release   = "Custom server";
+					ver.version = lib::version();
+					ver.release = "Custom server";
 					user->send(ver);
 
 					break;
@@ -436,7 +435,7 @@ bool Node::fillPing(udp::Message::Ping &ping) {
 		return false;
 	}
 
-	ping.serverVersion       = lib::version().blob64();
+	ping.version             = lib::version();
 	ping.userCount           = m_userManager->num();
 	ping.maxUserCount        = m_userManager->max();
 	ping.maxBandwidthPerUser = m_bandwidth;

--- a/src/example/ExampleServer/Node.cpp
+++ b/src/example/ExampleServer/Node.cpp
@@ -164,9 +164,9 @@ bool Node::startTCP() {
 			switch (pack.type()) {
 				case Type::Version: {
 					Message::Version ver;
-					ver.v1      = lib::version().blob32();
-					ver.v2      = lib::version().blob64();
-					ver.release = "Custom server";
+					ver.versionV1 = lib::version().blob32();
+					ver.versionV2 = lib::version().blob64();
+					ver.release   = "Custom server";
 					user->send(ver);
 
 					break;

--- a/src/proto/MumbleUDP.proto
+++ b/src/proto/MumbleUDP.proto
@@ -72,7 +72,7 @@ message Ping {
 	// The new protobuf Ping packet introduced with 1.5 drops support for the legacy version format
 	// since both server and client have to support this new format.
 	// (See https://github.com/mumble-voip/mumble/issues/5827)
-	uint64 server_version = 3;
+	uint64 server_version_v2 = 3;
 
 	// The amount of users currently connected to the server
 	uint32 user_count = 4;


### PR DESCRIPTION
Hi, sorry this MR took so long (health+life issues).

I am posting this unfinished, untested and possibly non-compiling merge request to have a dedicated communication channel.

In the first commit, I renamed the version fields a little. I also noticed that Message uses CamelCase while the proto uses underscores, which I also did not want to break.

In the later commit, I tried to check the version against a const ``UnknownVersion`` but that is when I realized the following:
I understand ``Message`` is an abstraction of the ``.proto`` fields for use in the custom clients/servers. But why don't we add a ``Version`` struct to ``Message`` (removing the versionV1 and versionV2 fields) and keep the conversion from raw numbers (and also v1->v2 v2->v1) to libmumble?
I do not think servers and clients using libmumble need to explicitly deal with the different version formats. Or Is there something I am missing here? I would try to implement that, if it is desired @davidebeatrici