### PR TITLE
Message: Implement tcp::Message::UDPTunnel properly

### DIFF
--- a/examples/ExampleClient/main.cpp
+++ b/examples/ExampleClient/main.cpp
@@ -58,8 +58,9 @@ static Connection::Feedback connectionFeedback(Connection &connection, std::cond
 	};
 
 	feedback.pack = [](Pack &pack) {
-		if (pack.type() != Type::UDPTunnel) {
-			printf("%s received!\n", Message::text(pack.type()).data());
+		const auto type = Message::type(pack);
+		if (type != Type::UDPTunnel) {
+			printf("%s received!\n", Message::text(type).data());
 		}
 	};
 

--- a/examples/ExampleServer/Node.cpp
+++ b/examples/ExampleServer/Node.cpp
@@ -155,13 +155,14 @@ bool Node::startTCP() {
 				return;
 			}
 
-			if (pack.type() != Type::UDPTunnel) {
-				printf("[#%u] (TCP) %s received!\n", user->id(), Message::text(pack.type()).data());
+			const auto type = Message::type(pack);
+			if (type != Type::UDPTunnel) {
+				printf("[#%u] (TCP) %s received!\n", user->id(), Message::text(type).data());
 			}
 
 			using Perm = Message::Perm;
 
-			switch (pack.type()) {
+			switch (type) {
 				case Type::Version: {
 					Message::Version ver;
 					ver.version = lib::version();
@@ -299,8 +300,6 @@ bool Node::startTCP() {
 					break;
 				case Type::PluginDataTransmission:
 					break;
-				case Type::Unknown:
-					break;
 			}
 		};
 
@@ -390,11 +389,12 @@ bool Node::startUDP() {
 
 		Pack pack(*header, packet.size());
 
-		if (pack.type() != Type::Audio) {
-			printf("[#%u] (UDP) %s received!\n", user->id(), Message::text(pack.type()).data());
+		const auto type = Message::type(pack);
+		if (type != Type::Audio) {
+			printf("[#%u] (UDP) %s received!\n", user->id(), Message::text(type).data());
 		}
 
-		switch (pack.type()) {
+		switch (type) {
 			case Type::Audio:
 				break;
 			case Type::Ping: {
@@ -416,8 +416,6 @@ bool Node::startUDP() {
 
 				break;
 			}
-			case Type::Unknown:
-				break;
 		}
 	};
 

--- a/include/mumble/Message.hpp
+++ b/include/mumble/Message.hpp
@@ -328,7 +328,7 @@ namespace tcp {
 	};
 
 	MUMBLE_MESSAGE_DECL(UDPTunnel) {
-		std::vector< std::byte > packet = {};
+		udp::Pack pack = {};
 
 		MUMBLE_MESSAGE_COMMON(UDPTunnel)
 	};

--- a/include/mumble/Pack.hpp
+++ b/include/mumble/Pack.hpp
@@ -8,7 +8,6 @@
 
 #include "Endian.hpp"
 #include "Macros.hpp"
-#include "Message.hpp"
 #include "Types.hpp"
 
 #include <algorithm>
@@ -53,41 +52,37 @@ protected:
 };
 
 namespace tcp {
+	struct Message;
+
 	MUMBLE_PACK(struct NetHeader {
-		uint16_t type = Endian::toNetwork(static_cast< uint16_t >(Message::Type::Unknown));
+		uint16_t type = Endian::toNetwork(std::numeric_limits< decltype(type) >::max());
 		uint32_t size = 0;
 	});
 
 	class MUMBLE_EXPORT Pack : public mumble::Pack< NetHeader > {
 	public:
-		using Type = Message::Type;
-
 		Pack(const Message &message, const uint32_t extraDataSize = 0);
 		Pack(const NetHeader &header = {}, const uint32_t extraDataSize = 0);
 		Pack(const google::protobuf::Message &proto, const uint32_t extraDataSize = 0);
 		virtual ~Pack();
 
 		virtual bool operator()(Message &message, uint32_t dataSize = std::numeric_limits< uint32_t >::max()) const;
-
-		virtual Type type() const { return static_cast< Type >(Endian::toHost(header().type)); }
 	};
 } // namespace tcp
 
 namespace udp {
-	MUMBLE_PACK(struct NetHeader { uint8_t type = static_cast< uint8_t >(Message::Type::Unknown); });
+	struct Message;
+
+	MUMBLE_PACK(struct NetHeader { uint8_t type = std::numeric_limits< decltype(type) >::max(); });
 
 	class MUMBLE_EXPORT Pack : public mumble::Pack< NetHeader > {
 	public:
-		using Type = Message::Type;
-
 		Pack(const Message &message, const uint32_t extraDataSize = 0);
 		Pack(const NetHeader &header = {}, const uint32_t dataSize = 0);
 		Pack(const google::protobuf::Message &proto, const uint32_t extraDataSize = 0);
 		virtual ~Pack();
 
 		virtual bool operator()(Message &message, uint32_t dataSize = std::numeric_limits< uint32_t >::max()) const;
-
-		virtual Type type() const { return static_cast< Type >(header().type); }
 	};
 } // namespace udp
 } // namespace mumble

--- a/src/Connection.cpp
+++ b/src/Connection.cpp
@@ -91,10 +91,8 @@ bool Connection::setCert(const Cert::Chain &cert, const Key &key) {
 }
 
 Code Connection::process(const bool wait, const std::function< bool() > halt) {
-	using Message   = tcp::Message;
 	using NetHeader = tcp::NetHeader;
 	using Pack      = tcp::Pack;
-	using Type      = Message::Type;
 
 	do {
 		NetHeader header;
@@ -112,13 +110,6 @@ Code Connection::process(const bool wait, const std::function< bool() > halt) {
 		}
 
 		Pack pack(header);
-		if (pack.type() == Type::Unknown) {
-			if (!m_p->m_closed.test_and_set()) {
-				m_p->m_feedback.failed(Code::Invalid);
-			}
-
-			return Code::Invalid;
-		}
 
 		code = m_p->read(pack.data(), wait, halt);
 		if (code != Code::Success) {

--- a/src/Pack.cpp
+++ b/src/Pack.cpp
@@ -954,7 +954,7 @@ bool TCP::operator()(Message &message, uint32_t dataSize) const {
 
 			auto &msg = static_cast< Message::UserList & >(message);
 			for (const auto &user : proto.users()) {
-				auto entry        = msg.users.emplace_back();
+				auto &entry       = msg.users.emplace_back();
 				entry.userID      = user.user_id();
 				entry.name        = user.name();
 				entry.lastSeen    = user.last_seen();
@@ -970,7 +970,7 @@ bool TCP::operator()(Message &message, uint32_t dataSize) const {
 			auto &msg = static_cast< Message::VoiceTarget & >(message);
 			msg.id    = proto.id();
 			for (const auto &target : proto.targets()) {
-				auto entry = msg.targets.emplace_back();
+				auto &entry = msg.targets.emplace_back();
 				for (const auto session : target.session()) {
 					entry.session.push_back(session);
 				}

--- a/src/Pack.cpp
+++ b/src/Pack.cpp
@@ -88,13 +88,14 @@ TCP::Pack(const Message &message, const uint32_t extraDataSize) {
 		case Type::UDPTunnel: {
 			auto &msg = static_cast< const Message::UDPTunnel & >(message);
 
-			NetHeader header;
-			header.type = Endian::toNetwork(static_cast< uint16_t >(message.type()));
-			header.size = Endian::toNetwork(static_cast< uint32_t >(msg.packet.size()));
+			auto &pack = msg.pack;
 
-			*this = std::move(Pack(header));
+			const NetHeader header = { Endian::toNetwork(static_cast< uint16_t >(Type::UDPTunnel)),
+									   Endian::toNetwork(static_cast< uint32_t >(pack.buf().size())) };
 
-			std::copy(msg.packet.cbegin(), msg.packet.cend(), data().begin());
+			*this = Pack(header, extraDataSize);
+
+			std::copy(pack.buf().begin(), pack.buf().end(), data().begin());
 
 			break;
 		}
@@ -648,7 +649,20 @@ bool TCP::operator()(Message &message, uint32_t dataSize) const {
 		}
 		case Type::UDPTunnel: {
 			auto &msg = static_cast< Message::UDPTunnel & >(message);
-			msg.packet.assign(m_buf.cbegin() + sizeof(NetHeader), m_buf.cend());
+
+			if (dataSize < sizeof(udp::NetHeader)) {
+				msg.pack = std::move(udp::Pack());
+				break;
+			}
+
+			auto packet = data();
+
+			auto &header = *reinterpret_cast< const udp::NetHeader * >(packet.data());
+			msg.pack     = std::move(udp::Pack(header, dataSize - static_cast< decltype(dataSize) >(sizeof(header))));
+
+			packet = packet.subspan(sizeof(header));
+
+			std::copy(packet.begin(), packet.end(), msg.pack.data().begin());
 
 			return true;
 		}

--- a/src/Pack.cpp
+++ b/src/Pack.cpp
@@ -548,8 +548,6 @@ TCP::Pack(const Message &message, const uint32_t extraDataSize) {
 
 			SET_BUF_AND_BREAK
 		}
-		case Type::Unknown:
-			break;
 	}
 }
 
@@ -614,8 +612,6 @@ UDP::Pack(const Message &message, const uint32_t extraDataSize) {
 
 			SET_BUF_AND_BREAK
 		}
-		case Type::Unknown:
-			break;
 	}
 }
 
@@ -625,7 +621,7 @@ UDP::~Pack() = default;
 bool TCP::operator()(Message &message, uint32_t dataSize) const {
 	using Type = Message::Type;
 
-	if (message.type() != type()) {
+	if (message.type() != Message::type(*this)) {
 		return false;
 	}
 
@@ -1128,8 +1124,6 @@ bool TCP::operator()(Message &message, uint32_t dataSize) const {
 
 			return true;
 		}
-		case Type::Unknown:
-			break;
 	}
 
 	return false;
@@ -1138,7 +1132,7 @@ bool TCP::operator()(Message &message, uint32_t dataSize) const {
 bool UDP::operator()(Message &message, uint32_t dataSize) const {
 	using Type = Message::Type;
 
-	if (message.type() != type()) {
+	if (message.type() != Message::type(*this)) {
 		return false;
 	}
 
@@ -1195,8 +1189,6 @@ bool UDP::operator()(Message &message, uint32_t dataSize) const {
 
 			return true;
 		}
-		case Type::Unknown:
-			break;
 	}
 
 	return false;

--- a/src/Peer.cpp
+++ b/src/Peer.cpp
@@ -348,7 +348,7 @@ void P::UDP::threadFunc(const uint32_t bufferSize) {
 			const auto code = m_socket->read(endpoint, packet);
 			switch (code) {
 				case Code::Success: {
-					if (pack.type() == Type::Ping) {
+					if (Message::type(pack) == Type::Ping) {
 						Message::Ping ping;
 						if (pack(ping, static_cast< uint32_t >(packet.size() - sizeof(NetHeader)))) {
 							if (m_feedback.ping) {


### PR DESCRIPTION
This allows us to embed `udp::Message::Audio` into `tcp::Message::UDPTunnel`.

Also, readability is improved as the `udp` namespace is much shorter.