### PR TITLE
CMake: Replace deprecated protobuf_generate_cpp()

### DIFF
--- a/src/proto/CMakeLists.txt
+++ b/src/proto/CMakeLists.txt
@@ -5,9 +5,6 @@
 
 find_package(Protobuf REQUIRED)
 
-protobuf_generate_cpp(TCP_CPP TCP_HPP "MumbleTCP.proto")
-protobuf_generate_cpp(UDP_CPP UDP_HPP "MumbleUDP.proto")
-
 add_library(Proto OBJECT)
 
 target_disable_warnings(Proto)
@@ -19,17 +16,14 @@ target_include_directories(Proto
 
 set_target_properties(Proto PROPERTIES UNITY_BUILD OFF)
 
-target_sources(Proto
-	PRIVATE
-		${TCP_CPP}
-		${UDP_CPP}
-		# Marking the headers as PUBLIC causes CMake's configure step to fail.
-		# The files are generated during the build step.
-		${TCP_HPP}
-		${UDP_HPP}
-)
-
 target_link_libraries(Proto
 	PRIVATE
 		protobuf::libprotobuf
+)
+
+protobuf_generate(
+	TARGET Proto
+	PROTOS
+		"MumbleTCP.proto"
+		"MumbleUDP.proto"
 )


### PR DESCRIPTION
I was getting an error when building (manjaro with cmake 3.28.1):
`Unknown CMake command "protobuf_generate_cpp"`

Found a solution here: https://stackoverflow.com/a/56896032/13580789

Udp: switched to protobuf_generate() as discussed